### PR TITLE
QIDI PLA Rapido Matte: Correcting density.

### DIFF
--- a/resources/profiles/Q Series/filament/QIDI PLA Rapido Matte.json
+++ b/resources/profiles/Q Series/filament/QIDI PLA Rapido Matte.json
@@ -7,7 +7,7 @@
     "instantiation": "false",
     "inherits": "fdm_filament_common",
     "additional_cooling_fan_speed": ["100"],
-    "filament_density": ["1.42"],
+    "filament_density": ["1.24"],
     "filament_type": ["PLA"],
     "nozzle_temperature_range_high": ["240"],
     "nozzle_temperature_range_low": ["190"],

--- a/resources/profiles/X 3 Series/filament/QIDI PLA Rapido Matte.json
+++ b/resources/profiles/X 3 Series/filament/QIDI PLA Rapido Matte.json
@@ -7,7 +7,7 @@
     "instantiation": "false",
     "inherits": "fdm_filament_common",
     "additional_cooling_fan_speed": ["100"],
-    "filament_density": ["1.42"],
+    "filament_density": ["1.24"],
     "filament_max_volumetric_speed": ["21"],
     "filament_type": ["PLA"],
     "nozzle_temperature_range_high": ["240"],

--- a/resources/profiles/X 4 Series/filament/QIDI PLA Rapido Matte.json
+++ b/resources/profiles/X 4 Series/filament/QIDI PLA Rapido Matte.json
@@ -7,7 +7,7 @@
     "instantiation": "false",
     "inherits": "fdm_filament_common",
     "additional_cooling_fan_speed": ["100"],
-    "filament_density": ["1.42"],
+    "filament_density": ["1.24"],
     "filament_type": ["PLA"],
     "nozzle_temperature_range_high": ["240"],
     "nozzle_temperature_range_low": ["190"],


### PR DESCRIPTION
The density for PLA is ~1.24g/cm3
Qidi PLA Rapido Matte had its density set to 1.42 while all other PLA types has its density set to 1.24.

