### PR TITLE
Fix build with QDT_RELEASE_TO_PUBLIC=0 

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -4375,8 +4375,8 @@ bool GUI_App::is_user_login()
     if (m_agent) {
         return m_agent->is_user_login();
     }
+#endif	
     return false;
-#endif
 }
 
 


### PR DESCRIPTION
Your recent changes broke the build again.
`bool` function should always return some value, so `return false;` should stay outside of `#if .. #endif`