### PR TITLE
Add CI to build on every push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,146 @@
+name: QIDIStudio-CI
+
+on: [push, pull_request]
+
+jobs:
+  main:    
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-2022, macos-15-intel]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Setup MSBUILD
+      if: startsWith(matrix.os, 'windows-')
+      uses: microsoft/setup-msbuild@v2
+      with:
+        vs-version: '[17.0,18.0)'
+
+    - name: Setup libraries on linux
+      if: startsWith(matrix.os, 'ubuntu-')    
+      run: |
+          sudo apt-get update
+          sudo apt-get install  -y \
+          build-essential \
+          cmake \
+          extra-cmake-modules \
+          libglu1-mesa-dev \
+          libgtk-3-dev \
+          libdbus-1-dev \
+          libwebkit2gtk-4.1-dev \
+          libboost*1.74-dev \
+          libglfw3-dev \
+          libnlopt*-dev \
+          libtbb-dev \
+          nasm \
+          libgstreamer1.0-dev \
+          libgstreamer-plugins-base1.0-dev \
+          libgstreamer-plugins-bad1.0-dev \
+          libcurl4-openssl-dev \
+          libosmesa6-dev
+          
+    - name: Setup libraries on Mac
+      if: startsWith(matrix.os, 'macos-')    
+      run: |
+          brew update
+          export HOMEBREW_NO_INSTALL_FROM_API=1
+          sed -i '' -e 's/disable!/#disable!/' /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/b/boost@1.76.rb
+          sed -i '' -e 's/disable!/#disable!/' /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/i/icu4c@74.rb
+          brew install \
+          boost@1.76 \
+          automake \
+          git \
+          nasm \
+          tbb \
+          texinfo \
+          zlib
+          
+    - name: Setup PkgConfig
+      if: startsWith(matrix.os, 'windows-')
+      run: choco install pkgconfiglite -y
+      
+    - name: Setup CMake
+      uses: ssrobins/install-cmake@v1
+      with:
+        version: 3.31.6
+
+    - name: Setup Perl
+      uses: shogo82148/actions-setup-perl@v1.36.0
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Build Dependencies on Windows
+      if: startsWith(matrix.os, 'windows-')
+      shell: cmd
+      run: |
+          set CMAKE_TLS_VERIFY=0
+          cd deps
+          mkdir build
+          cd build
+          mkdir QIDIStudio_dep
+          cmake ../ -G "Visual Studio 17 2022" -DDESTDIR="./QIDIStudio_dep" -DCMAKE_BUILD_TYPE=Release
+          msbuild /m ALL_BUILD.vcxproj
+
+    - name: Build QIDI Studio on Windows
+      if: startsWith(matrix.os, 'windows-')
+      shell: cmd
+      run: |
+          mkdir install_dir
+          mkdir build
+          cd build
+          cmake .. -G "Visual Studio 17 2022" -DQDT_RELEASE_TO_PUBLIC=0 -DCMAKE_PREFIX_PATH="${{ github.workspace }}\deps\build\QIDIStudio_dep\usr\local" -DCMAKE_INSTALL_PREFIX="../install_dir" -DCMAKE_BUILD_TYPE=Release -DWIN10SDK_PATH="C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0"
+          cmake --build . --target install --config Release
+    
+    - name: Build QIDI Studio on Linux 
+      if: startsWith(matrix.os, 'ubuntu-')
+      run: |
+          export CMAKE_TLS_VERIFY=0
+          sed -i "s/-DQDT_INTERNAL_TESTING=0/-DQDT_INTERNAL_TESTING=1 -DQDT_RELEASE_TO_PUBLIC=0/" BuildLinux.sh 
+          chmod +x BuildLinux.sh
+          ./BuildLinux.sh -dsi
+
+    - name: Build QIDI Studio on MacOS 
+      if: startsWith(matrix.os, 'macos-')
+      run: |
+          export CMAKE_TLS_VERIFY=0
+          export PATH="/usr/local/opt/curl/bin:$PATH"
+          export PATH="/usr/local/opt/icu4c@78/bin:$PATH"
+          export PATH="/usr/local/opt/icu4c@78/sbin:$PATH"       
+          export LDFLAGS="-L/usr/local/opt/curl/lib -L/usr/local/opt/boost@1.76/lib -L/usr/local/opt/icu4c@78/lib -L/usr/local/opt/zlib/lib -L/usr/local/opt/zstd/lib"
+          export CPPFLAGS="-I/usr/local/opt/curl/include -I/usr/local/opt/boost@1.76/include -I/usr/local/opt/icu4c@78/include -I/usr/local/opt/zlib/include -I/usr/local/opt/zstd/include"
+          export PKG_CONFIG_PATH="/usr/local/opt/curl/lib/pkgconfig:/usr/local/opt/boost@1.76/lib/pkgconfig:/usr/local/opt/icu4c@78/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig://usr/local/opt/zstd/lib/pkgconfig"
+          export CMAKE_PREFIX_PATH="/usr/local/opt/boost@1.76;/usr/local/opt/curl;/usr/local/opt/icu4c@78"
+          sed -i '' -e 's/-DCMAKE_PREFIX_PATH="$DEPS/-DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;$DEPS/' BuildMac.sh
+          sed -i '' -e 's/-DQDT_INTERNAL_TESTING=0/-DQDT_INTERNAL_TESTING=1/' BuildMac.sh 
+          sed -i '' -e 's/-DQDT_RELEASE_TO_PUBLIC=1/-DQDT_RELEASE_TO_PUBLIC=0/' BuildMac.sh
+          chmod +x BuildMac.sh
+          ./BuildMac.sh -t 14.0 -x
+
+    - name: Upload Artifacts on Windows
+      if: startsWith(matrix.os, 'windows-')
+      uses: actions/upload-artifact@v5.0.0
+      with:
+        name: QIDIStudio_windows
+        path: install_dir
+
+    - name: Upload Artifacts on MacOS
+      if: startsWith(matrix.os, 'macos-')
+      uses: actions/upload-artifact@v5.0.0
+      with:
+        name: QIDIStudio_macos
+        path: build/x86_64/QIDIStudio/QIDIStudio.app/       
+
+    - name: Upload Artifacts on Linux
+      if: startsWith(matrix.os, 'ubuntu-')
+      uses: actions/upload-artifact@v5.0.0
+      with:
+        name: QIDIStudio_linux
+        path: build/QIDIStudio.tar
+
+    - name: Upload Artifacts on Linux - Appimage
+      if: startsWith(matrix.os, 'ubuntu-')
+      uses: actions/upload-artifact@v5.0.0
+      with:
+        name: QIDIStudio_AppImage
+        path: build/QIDIStudio_ubu64.AppImage


### PR DESCRIPTION
To prevent future regressions, I suggest to add a github workflow to build on linux, windows and macos upon every push to repository. It's not perfect and can be further improved, but it's a good starting point. It also output the artifacts with build results, so it will allow users to test builds before official release, and in case of fixing some bugs you can suggest reporters to check those builds to confirm that bug was actually fixed - this will allow you to benefit from the community by having free testers of your code.