### PR TITLE
Added chamber heating for Q Series generic ABS

### DIFF
--- a/resources/profiles/Q Series/filament/Generic ABS.json
+++ b/resources/profiles/Q Series/filament/Generic ABS.json
@@ -8,6 +8,7 @@
     "inherits": "fdm_filament_common",
     "additional_cooling_fan_speed_unseal": ["0"],
     "additional_cooling_fan_speed": ["0"],
+    "chamber_temperatures": ["55"],
     "close_fan_the_first_x_layers": ["3"],
     "fan_cooling_layer_time": ["30"],
     "fan_max_speed": ["80"],


### PR DESCRIPTION
I noticed that for some reason generic ABS is the only ABS without any form of chamber heating. This caused some issues with warping on my Q2. This change should set the chamber temperature to 55 Celsius for generic ABS similar to the other ABS profiles.