### PR TITLE
Fix MacOS build on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,9 +47,6 @@ jobs:
           sed -i '' -e 's/disable!/#disable!/' /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/i/icu4c@74.rb
           curl https://raw.githubusercontent.com/Homebrew/homebrew-core/aba405a30fa1a608a12adeb56bea8e1c5975a42d/Formula/b/boost%401.76.rb > /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/b/boost@1.76.rb       
           sed -i '' -e 's#https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2#https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2#' /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/b/boost@1.76.rb
-          echo !!!!!!!!!!!!!!!
-          cat /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/b/boost@1.76.rb
-          echo !!!!!!!!!!!!!!!   
           brew install \
           icu4c@74 \
           boost@1.76 \


### PR DESCRIPTION
It seems homebrew completely removed boost@1.76 recently. For now I added custom download of this lib, while correct approach would be to build QIDIStudio with modern versions of libraries (I'll leave it up to you). Don't forget to squash when merging - there is a lot of debug commits in this branch, you don't want them to pollute your repo.