### PR TITLE
fix(ams): preserve connected device filament identity

### DIFF
--- a/resources/profiles/officiall_filas_list.cfg
+++ b/resources/profiles/officiall_filas_list.cfg
@@ -1,5 +1,5 @@
 [fila1]
-filament                       = PLA Rapido
+filament                       = Generic PLA
 min_temp                       = 190
 max_temp                       = 240
 box_min_temp                   = 0
@@ -7,7 +7,7 @@ box_max_temp                   = 0
 type                           = PLA
 
 [fila2]
-filament                       = PLA Matte
+filament                       = Generic PLA Silk
 min_temp                       = 190
 max_temp                       = 240
 box_min_temp                   = 0
@@ -15,7 +15,7 @@ box_max_temp                   = 0
 type                           = PLA
 
 [fila3]
-filament                       = PLA Metal
+filament                       = Generic PLA+
 min_temp                       = 190
 max_temp                       = 240
 box_min_temp                   = 0
@@ -23,410 +23,2731 @@ box_max_temp                   = 0
 type                           = PLA
 
 [fila4]
-filament                       = PLA Silk
-min_temp                       = 190
-max_temp                       = 240
-box_min_temp                   = 0
-box_max_temp                   = 0
-type                           = PLA
-
-[fila5]
-filament                       = PLA-CF
-min_temp                       = 210
-max_temp                       = 250
-box_min_temp                   = 0
-box_max_temp                   = 0
-type                           = PLA-CF
-
-[fila6]
-filament                       = PLA-Wood
-min_temp                       = 190
-max_temp                       = 240
-box_min_temp                   = 0
-box_max_temp                   = 45
-type                           = PLA
-
-[fila7]
-filament                       = PLA Basic
-min_temp                       = 190
-max_temp                       = 240
-box_min_temp                   = 0
-box_max_temp                   = 0
-type                           = PLA
-
-[fila8]
-filament                       = PLA Matte Basic
-min_temp                       = 190
-max_temp                       = 230
-box_min_temp                   = 0
-box_max_temp                   = 0
-type                           = PLA
-
-[fila9]
-filament                       = 
-min_temp                       = 
-max_temp                       = 
-box_min_temp                   = 
-box_max_temp                   = 
-type                           =
-
-[fila10]
-filament                       = Support For PLA
-min_temp                       = 210
-max_temp                       = 240
-box_min_temp                   = 0
-box_max_temp                   = 0
-type                           = PLA-S
-
-[fila11]
-filament                       = ABS Rapido
-min_temp                       = 240
-max_temp                       = 280
-box_min_temp                   = 0
-box_max_temp                   = 45
-type                           = ABS
-
-[fila12]
-filament                       = ABS-GF
-min_temp                       = 240
-max_temp                       = 280
-box_min_temp                   = 0
-box_max_temp                   = 45
-type                           = ABS-GF
-
-[fila13]
-filament                       = ABS-Metal
-min_temp                       = 240
-max_temp                       = 280
-box_min_temp                   = 0
-box_max_temp                   = 45
-type                           = ABS
-
-[fila14]
-filament                       = ABS-Odorless
-min_temp                       = 240
-max_temp                       = 280
-box_min_temp                   = 0
-box_max_temp                   = 45
-type                           = ABS
-
-[fila15]
-filament                       = 
-min_temp                       = 
-max_temp                       = 
-box_min_temp                   = 
-box_max_temp                   = 
-type                           =
-
-[fila16]
-filament                       = 
-min_temp                       = 
-max_temp                       = 
-box_min_temp                   = 
-box_max_temp                   = 
-type                           =
-
-[fila17]
-filament                       = 
-min_temp                       = 
-max_temp                       = 
-box_min_temp                   = 
-box_max_temp                   = 
-type                           =
-
-[fila18]
-filament                       = ASA
-min_temp                       = 240
-max_temp                       = 280
-box_min_temp                   = 0
-box_max_temp                   = 45
-type                           = ASA
-
-[fila19]
-filament                       = ASA-Aero
-min_temp                       = 240
-max_temp                       = 280
-box_min_temp                   = 0
-box_max_temp                   = 45
-type                           = ASA-AERO
-
-[fila20]
-filament                       = ASA-CF
-min_temp                       = 240
-max_temp                       = 280
-box_min_temp                   = 0
-box_max_temp                   = 45
-type                           = ASA-CF
-
-[fila21]
-filament                       = 
-min_temp                       = 
-max_temp                       = 
-box_min_temp                   = 
-box_max_temp                   = 
-type                           =
-
-[fila22]
-filament                       = 
-min_temp                       = 
-max_temp                       = 
-box_min_temp                   = 
-box_max_temp                   = 
-type                           =
-
-[fila23]
-filament                       = PC
-min_temp                       = 240
-max_temp                       = 280
-box_min_temp                   = 0
-box_max_temp                   = 0
-type                           = PC
-
-[fila24]
-filament                       = UltraPA
-min_temp                       = 260
-max_temp                       = 300
-box_min_temp                   = 0
-box_max_temp                   = 55
-type                           = UltraPA
-
-[fila25]
-filament                       = PA-CF
-min_temp                       = 260
-max_temp                       = 300
-box_min_temp                   = 0
-box_max_temp                   = 65
-type                           = PA-CF
-
-[fila26]
-filament                       = UltraPA-CF25
-min_temp                       = 300
-max_temp                       = 320
-box_min_temp                   = 0
-box_max_temp                   = 65
-type                           = UltraPA-CF25
-
-[fila27]
-filament                       = PA12-CF
-min_temp                       = 260
-max_temp                       = 300
-box_min_temp                   = 0
-box_max_temp                   = 65
-type                           = PA12-CF
-
-[fila28]
-filament                       = 
-min_temp                       = 
-max_temp                       = 
-box_min_temp                   = 
-box_max_temp                   = 
-type                           = 
-
-[fila29]
-filament                       = 
-min_temp                       = 
-max_temp                       = 
-box_min_temp                   = 
-box_max_temp                   = 
-type                           =
-
-[fila30]
-filament                       = PAHT-CF
-min_temp                       = 300
-max_temp                       = 320
-box_min_temp                   = 0
-box_max_temp                   = 65
-type                           = PAHT-CF
-
-[fila31]
-filament                       = PAHT-GF
-min_temp                       = 300
-max_temp                       = 320
-box_min_temp                   = 0
-box_max_temp                   = 65
-type                           = PAHT-GF
-
-[fila32]
-filament                       = Support For PAHT
-min_temp                       = 260
-max_temp                       = 280
-box_min_temp                   = 0
-box_max_temp                   = 65
-type                           = PAHT-S
-
-[fila33]
-filament                       = Support For PET/PA
-min_temp                       = 260
-max_temp                       = 280
-box_min_temp                   = 0
-box_max_temp                   = 65
-type                           = PA-S
-
-[fila34]
-filament                       = PC/ABS-FR
-min_temp                       = 260
-max_temp                       = 280
-box_min_temp                   = 0
-box_max_temp                   = 50
-type                           = PC-ABS-FR
-
-[fila35]
-filament                       = TPEE
-min_temp                       = 230
-max_temp                       = 260
-box_min_temp                   = 0
-box_max_temp                   = 0
-type                           = TPEE
-
-[fila36]
-filament                       = PEBA
-min_temp                       = 230
-max_temp                       = 260
-box_min_temp                   = 0
-box_max_temp                   = 0
-type                           = PEBA
-
-[fila37]
-filament                       = PET-CF
-min_temp                       = 280
-max_temp                       = 320
-box_min_temp                   = 0
-box_max_temp                   = 65
-type                           = PET-CF
-
-[fila38]
-filament                       = PET-GF
-min_temp                       = 280
-max_temp                       = 320
-box_min_temp                   = 0
-box_max_temp                   = 50
-type                           = PET-GF
-
-[fila39]
-filament                       = PETG Basic
-min_temp                       = 240
-max_temp                       = 280
-box_min_temp                   = 0
-box_max_temp                   = 45
-type                           = PETG
-
-[fila40]
-filament                       = PETG-Tough
-min_temp                       = 240
-max_temp                       = 275
-box_min_temp                   = 0
-box_max_temp                   = 45
-type                           = PETG
-
-[fila41]
-filament                       = PETG Rapido
+filament                       = Generic PETG
 min_temp                       = 220
 max_temp                       = 270
 box_min_temp                   = 0
 box_max_temp                   = 45
 type                           = PETG
 
-[fila42]
-filament                       = PETG-CF
-min_temp                       = 240
-max_temp                       = 270
-box_min_temp                   = 0
-box_max_temp                   = 45
-type                           = PETG-CF
-
-[fila43]
-filament                       = PETG-GF
-min_temp                       = 240
-max_temp                       = 270
-box_min_temp                   = 0
-box_max_temp                   = 45
-type                           = PETG-GF
-
-[fila44]
-filament                       = PPS-CF
-min_temp                       = 300
-max_temp                       = 350
-box_min_temp                   = 0
-box_max_temp                   = 65
-type                           = PPS-CF
-
-[fila45]
-filament                       = PETG Translucent
+[fila5]
+filament                       = Generic ABS
 min_temp                       = 240
 max_temp                       = 280
 box_min_temp                   = 0
 box_max_temp                   = 45
-type                           = PETG
+type                           = ABS
 
-[fila46]
-filament                       = PPS-GF
-min_temp                       = 300
-max_temp                       = 350
-box_min_temp                   = 0
-box_max_temp                   = 65
-type                           = PPS-GF
-
-[fila47]
-filament                       = PVA
-min_temp                       = 210
-max_temp                       = 250
-box_min_temp                   = 0
-box_max_temp                   = 50
-type                           = PVA
-
-[fila48]
-filament                       = TPU-AERO 64D
-min_temp                       = 200
-max_temp                       = 250
-box_min_temp                   = 0
-box_max_temp                   = 0
-type                           = TPU-AERO 64D
-
-[fila49]
-filament                       = TPU-Aero
-min_temp                       = 200
-max_temp                       = 250
-box_min_temp                   = 0
-box_max_temp                   = 0
-type                           = TPU-AERO
-
-[fila50]
-filament                       = TPU 95A-HF
+[fila6]
+filament                       = Generic TPU 95A
 min_temp                       = 200
 max_temp                       = 250
 box_min_temp                   = 0
 box_max_temp                   = 0
 type                           = TPU
 
+[fila7]
+filament                       = Generic PC
+min_temp                       = 260
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PC
+
+[fila8]
+filament                       = QIDI PLA Basic
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila9]
+filament                       = QIDI PLA Matte Basic
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila10]
+filament                       = QIDI PLA Rapido
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila11]
+filament                       = QIDI PLA Rapido Matte
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila12]
+filament                       = QIDI PLA Rapido Metal
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila13]
+filament                       = QIDI PLA Rapido Silk
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila14]
+filament                       = QIDI WOOD Rapido
+min_temp                       = 190
+max_temp                       = 220
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PLA
+
+[fila15]
+filament                       = QIDI PETG Basic
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila16]
+filament                       = QIDI PETG Rapido
+min_temp                       = 240
+max_temp                       = 275
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila17]
+filament                       = QIDI PETG Tough
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila18]
+filament                       = QIDI PETG Translucent
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila19]
+filament                       = QIDI PETG Translucent Glass Multi S1
+min_temp                       = 276
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila20]
+filament                       = QIDI PETG Translucent Glass Multi S2
+min_temp                       = 276
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila21]
+filament                       = QIDI PETG Translucent Glass Multi S3
+min_temp                       = 276
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila22]
+filament                       = QIDI PETG Translucent Glass Multi S4
+min_temp                       = 276
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila23]
+filament                       = QIDI PETG Translucent Glass Single S1
+min_temp                       = 276
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila24]
+filament                       = QIDI PETG Translucent Glass Single S2
+min_temp                       = 276
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila25]
+filament                       = QIDI PETG Translucent Glass Single S3
+min_temp                       = 276
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila26]
+filament                       = QIDI PETG Translucent Glass Single S4
+min_temp                       = 276
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila27]
+filament                       = QIDI ABS Odorless
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila28]
+filament                       = QIDI ABS Rapido
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila29]
+filament                       = QIDI ABS Rapido Metal
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila30]
+filament                       = QIDI ASA
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ASA
+
+[fila31]
+filament                       = QIDI TPU 95A-HF
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila32]
+filament                       = QIDI ABS-GF
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS-GF
+
+[fila33]
+filament                       = QIDI ASA-Aero
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ASA-AERO
+
+[fila34]
+filament                       = QIDI ASA-CF
+min_temp                       = 260
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ASA-CF
+
+[fila35]
+filament                       = QIDI Support For PET-PA
+min_temp                       = 260
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PA-S
+
+[fila36]
+filament                       = QIDI PA12-CF
+min_temp                       = 280
+max_temp                       = 300
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PA12-CF
+
+[fila37]
+filament                       = QIDI PAHT-CF
+min_temp                       = 300
+max_temp                       = 320
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PAHT-CF
+
+[fila38]
+filament                       = QIDI PAHT-GF
+min_temp                       = 300
+max_temp                       = 320
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PAHT-GF
+
+[fila39]
+filament                       = QIDI Support For PAHT
+min_temp                       = 260
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PAHT-S
+
+[fila40]
+filament                       = QIDI PC-ABS-FR
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 50
+type                           = PC-ABS-FR
+
+[fila41]
+filament                       = QIDI PEBA 95A
+min_temp                       = 230
+max_temp                       = 260
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PEBA
+
+[fila42]
+filament                       = QIDI PET-CF
+min_temp                       = 280
+max_temp                       = 320
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PET-CF
+
+[fila43]
+filament                       = QIDI PET-GF
+min_temp                       = 280
+max_temp                       = 320
+box_min_temp                   = 0
+box_max_temp                   = 50
+type                           = PET-GF
+
+[fila44]
+filament                       = QIDI PETG-CF
+min_temp                       = 240
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG-CF
+
+[fila45]
+filament                       = QIDI PETG-GF
+min_temp                       = 240
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG-GF
+
+[fila46]
+filament                       = QIDI PLA-CF
+min_temp                       = 210
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA-CF
+
+[fila47]
+filament                       = QIDI PPS-CF
+min_temp                       = 300
+max_temp                       = 350
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PPS-CF
+
+[fila48]
+filament                       = QIDI PPS-GF
+min_temp                       = 300
+max_temp                       = 350
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PPS-GF
+
+[fila49]
+filament                       = QIDI TPU-Aero
+min_temp                       = 230
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU-AERO
+
+[fila50]
+filament                       = QIDI TPU-GF
+min_temp                       = 240
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU-GF
+
+[fila51]
+filament                       = QIDI UltraPA
+min_temp                       = 250
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 55
+type                           = UltraPA
+
+[fila52]
+filament                       = QIDI UltraPA-CF25
+min_temp                       = 300
+max_temp                       = 320
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = UltraPA-CF25
+
+[fila53]
+filament                       = 3dfuel 3D Clean™
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila54]
+filament                       = 3dfuel Pro PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila55]
+filament                       = 3dfuel Standard PLA+
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila56]
+filament                       = 3dfuel Tough Pro PLA+
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila57]
+filament                       = 3dfuel Workday PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila58]
+filament                       = ReFuel™ 3D-Fuel Recycled Standard or Tough Pro PLA+
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila59]
+filament                       = 3dfuel Pro PCTG
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila60]
+filament                       = Amolen Glow-in-Dark PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila61]
+filament                       = Amolen Marble PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila62]
+filament                       = Amolen Matte PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila63]
+filament                       = Amolen Metal Fill PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila64]
+filament                       = Amolen PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila65]
+filament                       = Amolen Wood Fill PLA
+min_temp                       = 190
+max_temp                       = 220
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PLA
+
+[fila66]
+filament                       = Amolen PETG
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila67]
+filament                       = Amolen TPU
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila68]
+filament                       = Bambu PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila69]
+filament                       = Bambu PETG
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila70]
+filament                       = Bambu ABS
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila71]
+filament                       = Bambu Lab PETG CF Black
+min_temp                       = 240
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG-CF
+
+[fila72]
+filament                       = Bambu Lab PETG-CF
+min_temp                       = 240
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG-CF
+
+[fila73]
+filament                       = CarbonX PETG+CF Filament
+min_temp                       = 240
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG-CF
+
+[fila74]
+filament                       = CC3D SILK PLA SILK @Q2
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila75]
+filament                       = Creality CR-Wood filament
+min_temp                       = 190
+max_temp                       = 220
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PLA
+
+[fila76]
+filament                       = Creality Hyper Series PLA 3D Printing Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila77]
+filament                       = Creality PLA Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila78]
+filament                       = Creality PETG Filament
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila79]
+filament                       = Creality CR-ABS
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila80]
+filament                       = Creality Hyper Series ABS 3D Printing Filament
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila81]
+filament                       = Creality CR-TPU
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila82]
+filament                       = Creality CR-PLA Carbon filament
+min_temp                       = 210
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA-CF
+
+[fila83]
+filament                       = Das Filament PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila84]
+filament                       = DAS Filament PETG
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila85]
+filament                       = DURAMIC 3D Matte PLA Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila86]
+filament                       = DURAMIC 3D PLA Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila87]
+filament                       = DURAMIC 3D PLA Plus Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila88]
+filament                       = DURAMIC 3D Shiny Silk PLA Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila89]
+filament                       = DURAMIC 3D PETG Filament
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila90]
+filament                       = Elegoo PETG-CF Carbon Fiber Filament
+min_temp                       = 240
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG-CF
+
+[fila91]
+filament                       = Eryone PLA Matte High Speed Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila92]
+filament                       = Eryone PLA Matte High Speed One-Color Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila93]
+filament                       = Eryone PLA Matte High-Speed Gradient Multi-Color Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila94]
+filament                       = Eryone PLA Matte High-Speed Triple-Color Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila95]
+filament                       = Eryone PLA New Colors Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila96]
+filament                       = Eryone PLA New Product Color Collection Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila97]
+filament                       = Eryone PLA Silk Dual-Color Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila98]
+filament                       = Eryone PLA Silk High-Speed Dual-Color Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila99]
+filament                       = Eryone PLA Silk High-Speed Quadruple-Color Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila100]
+filament                       = Eryone PLA Silk High-Speed Triple-Color Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila101]
+filament                       = Eryone PLA Silk Triple-Color Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila102]
+filament                       = Eryone PETG Filament
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila103]
+filament                       = Eryone PP Filament
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila104]
+filament                       = Eryone ABS Filament
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila105]
+filament                       = Eryone ASA High-Speed Filament
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ASA
+
+[fila106]
+filament                       = Eryone TPU Filament
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila107]
+filament                       = Fiberlogy EASY PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila108]
+filament                       = Fiberlogy Matte PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila109]
+filament                       = Fiberlogy EASY PET-G
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila110]
+filament                       = Fiberlogy PCTG
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila111]
+filament                       = Fiberlogy ABS
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila112]
+filament                       = Fiberlogy ASA
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ASA
+
+[fila113]
+filament                       = Fiberlogy FiberFlex 30D
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila114]
+filament                       = Fiberlogy FiberFlex 40D
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila115]
+filament                       = Fiberlogy FiberFlex CF
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila116]
+filament                       = Fiberlogy MattFlex 40D
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila117]
+filament                       = Fiberlogy PETG+CF
+min_temp                       = 240
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG-CF
+
+[fila118]
+filament                       = Fiberlogy PA
+min_temp                       = 250
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 55
+type                           = UltraPA
+
+[fila119]
+filament                       = Flashforge HS PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila120]
+filament                       = Flashforge PCL
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila121]
+filament                       = Flashforge PLA Basic
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila122]
+filament                       = Flashforge PLA Pro
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila123]
+filament                       = Flashforge PLA Wood
+min_temp                       = 190
+max_temp                       = 220
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PLA
+
+[fila124]
+filament                       = Flashforge PETG
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila125]
+filament                       = Flashforge PETG ESD
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila126]
+filament                       = Flashforge PETG Pro
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila127]
+filament                       = Flashforge ABS
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila128]
+filament                       = Flashforge ABS Pro
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila129]
+filament                       = Flashforge HIPS
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila130]
+filament                       = Flashforge ASA
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ASA
+
+[fila131]
+filament                       = Flashforge Flexible - TPU 95A
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila132]
+filament                       = Flashforge PETG CF
+min_temp                       = 240
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG-CF
+
+[fila133]
+filament                       = Flashforge PLA CF
+min_temp                       = 210
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA-CF
+
+[fila134]
+filament                       = Formfutura Composite Filaments
+min_temp                       = 190
+max_temp                       = 220
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PLA
+
+[fila135]
+filament                       = Formfutura High Precision PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila136]
+filament                       = Formfutura PLA Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila137]
+filament                       = Formfutura Premium PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila138]
+filament                       = Formfutura Recycled PLA (rPLA)
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila139]
+filament                       = Formfutura PETG Filament
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila140]
+filament                       = Formfutura Recycled PET (rPET)
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila141]
+filament                       = Formfutura ABS Filament
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila142]
+filament                       = Formfutura EasyFil ABS
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila143]
+filament                       = Formfutura ASA Filament
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ASA
+
+[fila144]
+filament                       = Formfutura TPU Filament
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila145]
+filament                       = Formfutura Solvable Filaments
+min_temp                       = 260
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PA-S
+
+[fila146]
+filament                       = HATCHBOX PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila147]
+filament                       = HATCHBOX PETG
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila148]
+filament                       = HATCHBOX ABS
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila149]
+filament                       = HP3DF PLA SILK @Q2
+min_temp                       = 200
+max_temp                       = 230
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila150]
+filament                       = Iemai PLA 3D Printing Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila151]
+filament                       = Iemai Silk PLA 3D Printing Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila152]
+filament                       = Iemai PETG 3D Printing Filament
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila153]
+filament                       = Iemai PETG Transparent Filament
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila154]
+filament                       = Iemai PP 3D Printing Filament
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila155]
+filament                       = Iemai ABS 3D Printing Filament
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila156]
+filament                       = Iemai ASA 3D Printing Filament
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ASA
+
+[fila157]
+filament                       = Iemai TPU 3D Printing Filament
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila158]
+filament                       = Iemai PC 3D Printing Filament
+min_temp                       = 260
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PC
+
+[fila159]
+filament                       = Iemai PEEK 3D Printing Filament
+min_temp                       = 260
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PC
+
+[fila160]
+filament                       = Iemai PEI 1010 3D Printing Filament
+min_temp                       = 260
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PC
+
+[fila161]
+filament                       = Iemai PEI 9085 3D Printing Filament
+min_temp                       = 260
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PC
+
+[fila162]
+filament                       = Iemai PEKK 3D Printing Filament
+min_temp                       = 260
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PC
+
+[fila163]
+filament                       = Iemai PPSU 3D Printing Filament
+min_temp                       = 260
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PC
+
+[fila164]
+filament                       = Iemai GF-PA12 3D Printing Filament
+min_temp                       = 280
+max_temp                       = 320
+box_min_temp                   = 0
+box_max_temp                   = 50
+type                           = PET-GF
+
+[fila165]
+filament                       = Iemai CF-PETG 3D Printing Filament
+min_temp                       = 240
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG-CF
+
+[fila166]
+filament                       = Iemai PC CF Black 3D Printing Filament
+min_temp                       = 210
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA-CF
+
+[fila167]
+filament                       = Iemai Nylon 3D Printing Filament
+min_temp                       = 250
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 55
+type                           = UltraPA
+
+[fila168]
+filament                       = Iemai PA12 3D Printing Filament
+min_temp                       = 250
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 55
+type                           = UltraPA
+
+[fila169]
+filament                       = iSANMATE PLA i6 Matte Beige 3D Printing Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila170]
+filament                       = iSANMATE PLA i6 Matte Latte Brown 3D Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila171]
+filament                       = iSANMATE PLA i6 Matte Skin Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila172]
+filament                       = iSANMATE Transparent PLA Grey 3D Printer Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila173]
+filament                       = iSANMATE PETG Filament
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila174]
+filament                       = iSANMATE ABS Filament
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila175]
+filament                       = iSANMATE TPU Filament
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila176]
+filament                       = iSANMATE PEEK Filament
+min_temp                       = 260
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PC
+
+[fila177]
+filament                       = iSANMATE PEI Filament
+min_temp                       = 260
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PC
+
+[fila178]
+filament                       = iSANMATE PPSU Filament
+min_temp                       = 260
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PC
+
+[fila179]
+filament                       = iSANMATE Carbon Fiber Filament
+min_temp                       = 210
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA-CF
+
+[fila180]
+filament                       = KINGROON High-speed PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila181]
+filament                       = KINGROON Matte PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila182]
+filament                       = KINGROON PLA Basic
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila183]
+filament                       = KINGROON PLA+
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila184]
+filament                       = KINGROON Silk Multicolor PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila185]
+filament                       = KINGROON Silk PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila186]
+filament                       = KINGROON PETG
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila187]
+filament                       = KINGROON ABS
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila188]
+filament                       = KINGROON TPU
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila189]
+filament                       = KINGROON Carbon Fiber Black Filament
+min_temp                       = 210
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA-CF
+
+[fila190]
+filament                       = KINGROON Nylon
+min_temp                       = 250
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 55
+type                           = UltraPA
+
+[fila191]
+filament                       = Matterhackers MH Build Series Lightweight PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila192]
+filament                       = Matterhackers MH Build Series PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila193]
+filament                       = Matterhackers MH Build Series PLA-HS
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila194]
+filament                       = Matterhackers MH Build Series Silky PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila195]
+filament                       = Matterhackers MH Build Series Tough PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila196]
+filament                       = Matterhackers MH Build Series Translucent PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila197]
+filament                       = Matterhackers PRO Series PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila198]
+filament                       = Matterhackers PRO Series Tough PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila199]
+filament                       = Matterhackers Quantum PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila200]
+filament                       = Matterhackers MH Build Series PETG
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila201]
+filament                       = Matterhackers PRO Series PETG
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila202]
+filament                       = Matterhackers MH Build Series ABS
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila203]
+filament                       = Matterhackers PRO Series ABS
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila204]
+filament                       = Matterhackers MH Build Series TPU
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila205]
+filament                       = Matterhackers PRO Series Flex TPE
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila206]
+filament                       = Matterhackers PRO Series NylonX
+min_temp                       = 280
+max_temp                       = 300
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PA12-CF
+
+[fila207]
+filament                       = Matterhackers PRO Series NylonG
+min_temp                       = 300
+max_temp                       = 320
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PAHT-GF
+
+[fila208]
+filament                       = Matterhackers PRO Series NylonK
+min_temp                       = 250
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 55
+type                           = UltraPA
+
+[fila209]
+filament                       = NinjaFlex
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila210]
+filament                       = Ninjaflex Ninjatek Armadillo
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila211]
+filament                       = Ninjaflex Ninjatek Cheetah
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila212]
+filament                       = Overture PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila213]
+filament                       = Overture ABS
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila214]
+filament                       = PolyLite PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila215]
+filament                       = Polymaker PLA Tough
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila216]
+filament                       = Polymaker PolyLite PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila217]
+filament                       = Polymaker PolyLite PLA Dual Matte
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila218]
+filament                       = Polymaker PolyLite PLA Galaxy
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila219]
+filament                       = Polymaker PolyLite PLA Gradient Matte
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila220]
+filament                       = Polymaker PolyLite PLA Marble
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila221]
+filament                       = Polymaker PolyLite PLA Matte
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila222]
+filament                       = Polymaker PolyLite PLA Satin
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila223]
+filament                       = Polymaker PolyMax PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila224]
+filament                       = Polymaker PolyTerra PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila225]
+filament                       = Polymaker PolyLite PETG
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila226]
+filament                       = PolyLite ABS
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila227]
+filament                       = Polymaker PolyLite ABS
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila228]
+filament                       = Polymaker PolyLite ASA
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ASA
+
+[fila229]
+filament                       = Polymaker PolyLite TPU
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila230]
+filament                       = Polymaker PolyLite PC
+min_temp                       = 260
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PC
+
+[fila231]
+filament                       = Polymaker PolyLite Carbon Fiber
+min_temp                       = 210
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA-CF
+
+[fila232]
+filament                       = Polymaker PolyLite Nylon
+min_temp                       = 250
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 55
+type                           = UltraPA
+
+[fila233]
+filament                       = Polymaker PolyMide CoPA
+min_temp                       = 250
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 55
+type                           = UltraPA
+
+[fila234]
+filament                       = Prusament PETG Magnetite 40%
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila235]
+filament                       = Prusament PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila236]
+filament                       = Prusament Woodfill
+min_temp                       = 190
+max_temp                       = 220
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PLA
+
+[fila237]
+filament                       = Prusament PETG
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila238]
+filament                       = Prusament TPU 95A
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila239]
+filament                       = Prusament PC Space Grade
+min_temp                       = 260
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PC
+
+[fila240]
+filament                       = Prusament PEI 1010
+min_temp                       = 260
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PC
+
+[fila241]
+filament                       = Prusament PP Glass Fiber
+min_temp                       = 280
+max_temp                       = 320
+box_min_temp                   = 0
+box_max_temp                   = 50
+type                           = PET-GF
+
+[fila242]
+filament                       = Prusament PP Carbon Fiber
+min_temp                       = 210
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA-CF
+
+[fila243]
+filament                       = Prusament PA11
+min_temp                       = 250
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 55
+type                           = UltraPA
+
+[fila244]
+filament                       = Raise3D Premium PLA Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila245]
+filament                       = Raise3D Premium PLA Filament - RFID
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila246]
+filament                       = Raise3D PP
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila247]
+filament                       = Raise3D Premium PETG Filament
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila248]
+filament                       = Raise3D Premium ABS Filament
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila249]
+filament                       = Raise3D Premium ASA Filament
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ASA
+
+[fila250]
+filament                       = Raise3D Premium TPU-95A
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila251]
+filament                       = Raise3D Premium PC Filament
+min_temp                       = 260
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PC
+
+[fila252]
+filament                       = Raise3D Premium PVA Filament
+min_temp                       = 260
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PA-S
+
+[fila253]
+filament                       = Cleaning Filament Neutral
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila254]
+filament                       = Real PLA Gray
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila255]
+filament                       = Spectrum PLA Matt Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila256]
+filament                       = Spectrum PLA Special Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila257]
+filament                       = Spectrum Silk PLA Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila258]
+filament                       = Spectrum PET-G Matt Filament
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila259]
+filament                       = Spectrum PETG Filament
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila260]
+filament                       = Spectrum Premium PCTG
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila261]
+filament                       = Spectrum ABS Filament
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila262]
+filament                       = Spectrum ASA 275 Filament
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ASA
+
+[fila263]
+filament                       = Spectrum Carbon Fiber Filament
+min_temp                       = 210
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA-CF
+
+[fila264]
+filament                       = Sunlu Matte PLA 3D Printer Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila265]
+filament                       = Sunlu Optimized Wood PLA 3D Printer Filament
+min_temp                       = 190
+max_temp                       = 220
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PLA
+
+[fila266]
+filament                       = Sunlu PLA 3D Pen Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila267]
+filament                       = Sunlu PLA 3D Printer Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila268]
+filament                       = Sunlu PLA Meta 3D Printer Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila269]
+filament                       = Sunlu PLA+ (PLA Plus) 3D Printer Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila270]
+filament                       = Sunlu SILK PLA 3D Printer Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila271]
+filament                       = Sunlu PETG 3D Printer Filament
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila272]
+filament                       = Sunlu ABS 3D Printer Filament
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila273]
+filament                       = Sunlu ASA 3D Printer Filament
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ASA
+
+[fila274]
+filament                       = Sunlu TPU 3D Printer Filament
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila275]
+filament                       = Sunlu Fibreheart ABS-GF Filament
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS-GF
+
+[fila276]
+filament                       = Sunlu Fibreheart ABS-CF Core Filament
+min_temp                       = 260
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ASA-CF
+
+[fila277]
+filament                       = Sunlu Fibreheart PET-GF 3D Printing Filament
+min_temp                       = 280
+max_temp                       = 320
+box_min_temp                   = 0
+box_max_temp                   = 50
+type                           = PET-GF
+
+[fila278]
+filament                       = Sunlu Carbon Fiber PLA 3D Printer Filament
+min_temp                       = 210
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA-CF
+
+[fila279]
+filament                       = PETG CF - The Filament
+min_temp                       = 240
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG-CF
+
+[fila280]
+filament                       = UltiMaker NFC PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila281]
+filament                       = UltiMaker NFC Tough PLA
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila282]
+filament                       = Ultimaker CPE
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila283]
+filament                       = Ultimaker PETG
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila284]
+filament                       = Ultimaker ABS
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila285]
+filament                       = Ultimaker ASA
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ASA
+
+[fila286]
+filament                       = Ultimaker TPU 95A
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila287]
+filament                       = Ultimaker PC
+min_temp                       = 260
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PC
+
+[fila288]
+filament                       = UltiMaker Breakaway
+min_temp                       = 260
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PA-S
+
+[fila289]
+filament                       = UltiMaker NFC Nylon CF Slide
+min_temp                       = 280
+max_temp                       = 300
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PA12-CF
+
+[fila290]
+filament                       = UltiMaker PET CF
+min_temp                       = 280
+max_temp                       = 320
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PET-CF
+
+[fila291]
+filament                       = UltiMaker NFC PPS-CF
+min_temp                       = 300
+max_temp                       = 350
+box_min_temp                   = 0
+box_max_temp                   = 65
+type                           = PPS-CF
+
+[fila292]
+filament                       = Ultimaker Nylon
+min_temp                       = 250
+max_temp                       = 290
+box_min_temp                   = 0
+box_max_temp                   = 55
+type                           = UltraPA
+
+[fila293]
+filament                       = ZIRO Galaxy PLA Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila294]
+filament                       = ZIRO Matte PLA Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila295]
+filament                       = ZIRO PLA PRO Basic Color Series Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila296]
+filament                       = ZIRO Silk PLA Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila297]
+filament                       = ZIRO Translucent PLA Filament
+min_temp                       = 190
+max_temp                       = 240
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA
+
+[fila298]
+filament                       = ZIRO PETG Filament
+min_temp                       = 220
+max_temp                       = 270
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = PETG
+
+[fila299]
+filament                       = ZIRO ABS Filament
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ABS
+
+[fila300]
+filament                       = ZIRO ASA Filament
+min_temp                       = 240
+max_temp                       = 280
+box_min_temp                   = 0
+box_max_temp                   = 45
+type                           = ASA
+
+[fila301]
+filament                       = ZIRO Shore 95A Hardness TPU Filament
+min_temp                       = 200
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = TPU
+
+[fila302]
+filament                       = ZIRO Carbon Fiber PLA Filament
+min_temp                       = 210
+max_temp                       = 250
+box_min_temp                   = 0
+box_max_temp                   = 0
+type                           = PLA-CF
+
 [colordict]
-1                              = #FAFAFA
-2                              = #060606
-3                              = #D9E3ED
-4                              = #5CF30F
-5                              = #63E492
-6                              = #2850FF
-7                              = #FE98FE
-8                              = #DFD628
-9                              = #228332
-10                             = #99DEFF
-11                             = #1714B0
-12                             = #CEC0FE
-13                             = #CADE4B
-14                             = #1353AB
-15                             = #5EA9FD
-16                             = #A878FF
-17                             = #FE717A
-18                             = #FF362D
-19                             = #E2DFCD
-20                             = #898F9B
-21                             = #6E3812
-22                             = #CAC59F
-23                             = #F28636
-24                             = #B87F2B
+1                             = #EEEEEE
+2                             = #EEEEEE
+3                             = #EEEEEE
+4                             = #EEEEEE
+5                             = #EEEEEE
+6                             = #EEEEEE
+7                             = #EEEEEE
+8                             = #EEEEEE
+9                             = #EEEEEE
+10                            = #EEEEEE
+11                            = #EEEEEE
+12                            = #EEEEEE
+13                            = #EEEEEE
+14                            = #EEEEEE
+15                            = #EEEEEE
+16                            = #EEEEEE
+17                            = #EEEEEE
+18                            = #EEEEEE
+19                            = #EEEEEEBB
+20                            = #CC2222CC
+21                            = #222222FF
+22                            = #CCAA22CC
+23                            = #EEEEEE
+24                            = #CC2222CC
+25                            = #222222FF
+26                            = #CCAA22CC
+27                            = #EEEEEE
+28                            = #EEEEEE
+29                            = #EEEEEE
+30                            = #EEEEEE
+31                            = #EEEEEE
+32                            = #EEEEEE
+33                            = #EEEEEE
+34                            = #EEEEEE
+35                            = #EEEEEE
+36                            = #EEEEEE
+37                            = #EEEEEE
+38                            = #EEEEEE
+39                            = #EEEEEE
+40                            = #EEEEEE
+41                            = #EEEEEE
+42                            = #EEEEEE
+43                            = #EEEEEE
+44                            = #EEEEEE
+45                            = #EEEEEE
+46                            = #EEEEEE
+47                            = #EEEEEE
+48                            = #EEEEEE
+49                            = #EEEEEE
+50                            = #EEEEEE
+51                            = #EEEEEE
+52                            = #EEEEEE
+53                            = #EEEEEE
+54                            = #EEEEEE
+55                            = #EEEEEE
+56                            = #EEEEEE
+57                            = #EEEEEE
+58                            = #EEEEEE
+59                            = #EEEEEE
+60                            = #EEEEEE
+61                            = #EEEEEE
+62                            = #EEEEEE
+63                            = #EEEEEE
+64                            = #EEEEEE
+65                            = #EEEEEE
+66                            = #EEEEEE
+67                            = #EEEEEE
+68                            = #EEEEEE
+69                            = #EEEEEE
+70                            = #EEEEEE
+71                            = #EEEEEE
+72                            = #EEEEEE
+73                            = #EEEEEE
+74                            = #EEEEEE
+75                            = #EEEEEE
+76                            = #EEEEEE
+77                            = #EEEEEE
+78                            = #EEEEEE
+79                            = #EEEEEE
+80                            = #EEEEEE
+81                            = #EEEEEE
+82                            = #EEEEEE
+83                            = #EEEEEE
+84                            = #EEEEEE
+85                            = #EEEEEE
+86                            = #EEEEEE
+87                            = #EEEEEE
+88                            = #EEEEEE
+89                            = #EEEEEE
+90                            = #EEEEEE
+91                            = #EEEEEE
+92                            = #EEEEEE
+93                            = #EEEEEE
+94                            = #EEEEEE
+95                            = #EEEEEE
+96                            = #EEEEEE
+97                            = #EEEEEE
+98                            = #EEEEEE
+99                            = #EEEEEE
+100                           = #EEEEEE
+101                           = #EEEEEE
+102                           = #EEEEEE
+103                           = #EEEEEE
+104                           = #EEEEEE
+105                           = #EEEEEE
+106                           = #EEEEEE
+107                           = #EEEEEE
+108                           = #EEEEEE
+109                           = #EEEEEE
+110                           = #EEEEEE
+111                           = #EEEEEE
+112                           = #EEEEEE
+113                           = #EEEEEE
+114                           = #EEEEEE
+115                           = #EEEEEE
+116                           = #EEEEEE
+117                           = #EEEEEE
+118                           = #EEEEEE
+119                           = #EEEEEE
+120                           = #EEEEEE
+121                           = #EEEEEE
+122                           = #EEEEEE
+123                           = #EEEEEE
+124                           = #EEEEEE
+125                           = #EEEEEE
+126                           = #EEEEEE
+127                           = #EEEEEE
+128                           = #EEEEEE
+129                           = #EEEEEE
+130                           = #EEEEEE
+131                           = #EEEEEE
+132                           = #EEEEEE
+133                           = #EEEEEE
+134                           = #EEEEEE
+135                           = #EEEEEE
+136                           = #EEEEEE
+137                           = #EEEEEE
+138                           = #EEEEEE
+139                           = #EEEEEE
+140                           = #EEEEEE
+141                           = #EEEEEE
+142                           = #EEEEEE
+143                           = #EEEEEE
+144                           = #EEEEEE
+145                           = #EEEEEE
+146                           = #EEEEEE
+147                           = #EEEEEE
+148                           = #EEEEEE
+149                           = #EEEEEE
+150                           = #EEEEEE
+151                           = #EEEEEE
+152                           = #EEEEEE
+153                           = #EEEEEE
+154                           = #EEEEEE
+155                           = #EEEEEE
+156                           = #EEEEEE
+157                           = #EEEEEE
+158                           = #EEEEEE
+159                           = #EEEEEE
+160                           = #EEEEEE
+161                           = #EEEEEE
+162                           = #EEEEEE
+163                           = #EEEEEE
+164                           = #EEEEEE
+165                           = #EEEEEE
+166                           = #EEEEEE
+167                           = #EEEEEE
+168                           = #EEEEEE
+169                           = #EEEEEE
+170                           = #EEEEEE
+171                           = #EEEEEE
+172                           = #EEEEEE
+173                           = #EEEEEE
+174                           = #EEEEEE
+175                           = #EEEEEE
+176                           = #EEEEEE
+177                           = #EEEEEE
+178                           = #EEEEEE
+179                           = #EEEEEE
+180                           = #EEEEEE
+181                           = #EEEEEE
+182                           = #EEEEEE
+183                           = #EEEEEE
+184                           = #EEEEEE
+185                           = #EEEEEE
+186                           = #EEEEEE
+187                           = #EEEEEE
+188                           = #EEEEEE
+189                           = #EEEEEE
+190                           = #EEEEEE
+191                           = #EEEEEE
+192                           = #EEEEEE
+193                           = #EEEEEE
+194                           = #EEEEEE
+195                           = #EEEEEE
+196                           = #EEEEEE
+197                           = #EEEEEE
+198                           = #EEEEEE
+199                           = #EEEEEE
+200                           = #EEEEEE
+201                           = #EEEEEE
+202                           = #EEEEEE
+203                           = #EEEEEE
+204                           = #EEEEEE
+205                           = #EEEEEE
+206                           = #EEEEEE
+207                           = #EEEEEE
+208                           = #EEEEEE
+209                           = #EEEEEE
+210                           = #EEEEEE
+211                           = #EEEEEE
+212                           = #EEEEEE
+213                           = #EEEEEE
+214                           = #EEEEEE
+215                           = #EEEEEE
+216                           = #EEEEEE
+217                           = #EEEEEE
+218                           = #EEEEEE
+219                           = #EEEEEE
+220                           = #EEEEEE
+221                           = #EEEEEE
+222                           = #EEEEEE
+223                           = #EEEEEE
+224                           = #EEEEEE
+225                           = #EEEEEE
+226                           = #EEEEEE
+227                           = #EEEEEE
+228                           = #EEEEEE
+229                           = #EEEEEE
+230                           = #EEEEEE
+231                           = #EEEEEE
+232                           = #EEEEEE
+233                           = #EEEEEE
+234                           = #EEEEEE
+235                           = #EEEEEE
+236                           = #EEEEEE
+237                           = #EEEEEE
+238                           = #EEEEEE
+239                           = #EEEEEE
+240                           = #EEEEEE
+241                           = #EEEEEE
+242                           = #EEEEEE
+243                           = #EEEEEE
+244                           = #EEEEEE
+245                           = #EEEEEE
+246                           = #EEEEEE
+247                           = #EEEEEE
+248                           = #EEEEEE
+249                           = #EEEEEE
+250                           = #EEEEEE
+251                           = #EEEEEE
+252                           = #EEEEEE
+253                           = #EEEEEE
+254                           = #EEEEEE
+255                           = #EEEEEE
+256                           = #EEEEEE
+257                           = #EEEEEE
+258                           = #EEEEEE
+259                           = #EEEEEE
+260                           = #EEEEEE
+261                           = #EEEEEE
+262                           = #EEEEEE
+263                           = #EEEEEE
+264                           = #EEEEEE
+265                           = #EEEEEE
+266                           = #EEEEEE
+267                           = #EEEEEE
+268                           = #EEEEEE
+269                           = #EEEEEE
+270                           = #EEEEEE
+271                           = #EEEEEE
+272                           = #EEEEEE
+273                           = #EEEEEE
+274                           = #EEEEEE
+275                           = #EEEEEE
+276                           = #EEEEEE
+277                           = #EEEEEE
+278                           = #EEEEEE
+279                           = #EEEEEE
+280                           = #EEEEEE
+281                           = #EEEEEE
+282                           = #EEEEEE
+283                           = #EEEEEE
+284                           = #EEEEEE
+285                           = #EEEEEE
+286                           = #EEEEEE
+287                           = #EEEEEE
+288                           = #EEEEEE
+289                           = #EEEEEE
+290                           = #EEEEEE
+291                           = #EEEEEE
+292                           = #EEEEEE
+293                           = #EEEEEE
+294                           = #EEEEEE
+295                           = #EEEEEE
+296                           = #EEEEEE
+297                           = #EEEEEE
+298                           = #EEEEEE
+299                           = #EEEEEE
+300                           = #EEEEEE
+301                           = #EEEEEE
+302                           = #EEEEEE
 
 [vendor_list]
-0                              = Generic
-1                              = QIDI
-
-
-
+0                             = Generic
+1                             = QIDI
+2                             = 3dfuel
+3                             = Amolen
+4                             = Bambu Lab
+5                             = CarbonX
+6                             = CC3D SILK
+7                             = Creality
+8                             = Das Filament
+9                             = Duramic 3d
+10                            = Elegoo
+11                            = Eryone
+12                            = Fiberlogy
+13                            = Flashforge
+14                            = Formfutura
+15                            = HATCHBOX
+16                            = HP3DF
+17                            = Iemai
+18                            = Isanmate
+19                            = Kingroon
+20                            = MatterHackers
+21                            = Ninjaflex Ninjatek
+22                            = Overture
+23                            = Polymaker
+24                            = Prusament
+25                            = Raise3d
+26                            = Real Filament
+27                            = Spectrum
+28                            = Sunlu
+29                            = The Filament
+30                            = UltiMaker
+31                            = Ziro

--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -1016,79 +1016,86 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
     m_input_k_val->GetTextCtrl()->SetValue(k);
     m_input_n_val->GetTextCtrl()->SetValue(n);
 
-    int idx = 0;
     wxArrayString filament_items;
     wxString qidi_filament_name;
     wxString hint_filament_name; // the hint type to be selected
     std::unordered_map<wxString, wxString> query_filament_vendors;// some information for sort
     std::unordered_map<wxString, wxString> query_filament_types;  //
 
-    std::set<std::string> filament_id_set;
+    std::set<std::string> shown_filament_names;
     PresetBundle *        preset_bundle = wxGetApp().preset_bundle;
     std::ostringstream    stream;
-   
-    //stream << std::fixed << std::setprecision(1) << obj->GetExtderSystem()->GetNozzleDiameter(0);
+
+    if (obj && obj->GetExtderSystem())
+        stream << std::fixed << std::setprecision(1) << obj->GetExtderSystem()->GetNozzleDiameter(0);
     std::string nozzle_diameter_str = stream.str();
-	//std::set<std::string> printer_names = preset_bundle->get_printer_names_by_printer_type_and_nozzle(DevPrinterConfigUtil::get_printer_display_name(obj->printer_type), nozzle_diameter_str);
-    std::set<std::string> printer_names = { "X-Max 4" };
+
+    std::set<std::string> printer_names;
+    if (preset_bundle && obj) {
+	    printer_names = preset_bundle->get_printer_names_by_printer_type_and_nozzle(DevPrinterConfigUtil::get_printer_display_name(obj->printer_type), nozzle_diameter_str);
+        auto display_name = DevPrinterConfigUtil::get_printer_display_name(obj->printer_type);
+        if (!display_name.empty())
+            printer_names.insert(display_name);
+    }
 
     auto & filaments = preset_bundle->filaments;
     if (preset_bundle) {
-        // BOOST_LOG_TRIVIAL(trace) << "system_preset_bundle filament number=" << filaments.size();
+        BOOST_LOG_TRIVIAL(trace) << "system_preset_bundle filament number=" << filaments.size();
         for (auto filament_it = filaments.begin(); filament_it != filaments.end(); filament_it++) {
             //filter by system preset
             Preset& preset = *filament_it;
-            /*The situation where the user preset is not displayed is as follows:
-                1. Not a root preset
-                2. Not system preset and the printer firmware does not support user preset */
-            if (preset_bundle->filaments.get_preset_base(*filament_it) != &preset || (!filament_it->is_system /* &&!obj->is_support_user_preset*/)) {
+            if (preset_bundle->filaments.get_preset_base(*filament_it) != &preset) {
                 continue;
             }
 
             ConfigOption *       printer_opt  = filament_it->config.option("compatible_printers");
             ConfigOptionStrings *printer_strs = dynamic_cast<ConfigOptionStrings *>(printer_opt);
-            for (auto printer_str : printer_strs->values) {
-                if (printer_names.find(printer_str) != printer_names.end()) {
-                    if (filament_id_set.find(filament_it->filament_id) != filament_id_set.end()) {
-                        continue;
-                    } else {
-                        filament_id_set.insert(filament_it->filament_id);
-                        // name matched
-                        auto fialment_alias = filaments.get_preset_alias(*filament_it, true);
-                        if (!fialment_alias.empty()) {
-                            filament_items.push_back(from_u8(fialment_alias));
-                            _collect_filament_info(fialment_alias, preset, query_filament_vendors, query_filament_types);
+            bool compatible_printer = printer_names.empty();
+            if (printer_strs) {
+                for (const auto &printer_str : printer_strs->values) {
+                    if (printer_names.find(printer_str) != printer_names.end()) {
+                        compatible_printer = true;
+                        break;
+                    }
+                }
+            }
+            if (!compatible_printer)
+                continue;
 
-                            FilamentInfos filament_infos;
-                            filament_infos.filament_id         = filament_it->filament_id;
-                            filament_infos.setting_id          = filament_it->setting_id;
-                            map_filament_items[fialment_alias] = filament_infos;
-                        }
+            auto fialment_alias = filaments.get_preset_alias(*filament_it, true);
+            if (fialment_alias.empty())
+                continue;
+            if (!shown_filament_names.insert(fialment_alias).second)
+                continue;
 
-                        if (filament_it->filament_id == ams_filament_id) {
-                            hint_filament_name  = from_u8(fialment_alias);
-                            qidi_filament_name = from_u8(fialment_alias);
+            filament_items.push_back(from_u8(fialment_alias));
+            _collect_filament_info(fialment_alias, preset, query_filament_vendors, query_filament_types);
+
+            FilamentInfos filament_infos;
+            filament_infos.filament_id         = filament_it->filament_id;
+            filament_infos.setting_id          = filament_it->setting_id;
+            map_filament_items[fialment_alias] = filament_infos;
+
+            if (filament_it->filament_id == ams_filament_id) {
+                hint_filament_name  = from_u8(fialment_alias);
+                qidi_filament_name = from_u8(fialment_alias);
 
 
-                            // update if nozzle_temperature_range is found
-                            ConfigOption *opt_min = filament_it->config.option("nozzle_temperature_range_low");
-                            if (opt_min) {
-                                ConfigOptionInts *opt_min_ints = dynamic_cast<ConfigOptionInts *>(opt_min);
-                                if (opt_min_ints) {
-                                    wxString text_nozzle_temp_min = wxString::Format("%d", opt_min_ints->get_at(0));
-                                    m_input_nozzle_min->GetTextCtrl()->SetValue(text_nozzle_temp_min);
-                                }
-                            }
-                            ConfigOption *opt_max = filament_it->config.option("nozzle_temperature_range_high");
-                            if (opt_max) {
-                                ConfigOptionInts *opt_max_ints = dynamic_cast<ConfigOptionInts *>(opt_max);
-                                if (opt_max_ints) {
-                                    wxString text_nozzle_temp_max = wxString::Format("%d", opt_max_ints->get_at(0));
-                                    m_input_nozzle_max->GetTextCtrl()->SetValue(text_nozzle_temp_max);
-                                }
-                            }
-                        }
-                        idx++;
+                // update if nozzle_temperature_range is found
+                ConfigOption *opt_min = filament_it->config.option("nozzle_temperature_range_low");
+                if (opt_min) {
+                    ConfigOptionInts *opt_min_ints = dynamic_cast<ConfigOptionInts *>(opt_min);
+                    if (opt_min_ints) {
+                        wxString text_nozzle_temp_min = wxString::Format("%d", opt_min_ints->get_at(0));
+                        m_input_nozzle_min->GetTextCtrl()->SetValue(text_nozzle_temp_min);
+                    }
+                }
+                ConfigOption *opt_max = filament_it->config.option("nozzle_temperature_range_high");
+                if (opt_max) {
+                    ConfigOptionInts *opt_max_ints = dynamic_cast<ConfigOptionInts *>(opt_max);
+                    if (opt_max_ints) {
+                        wxString text_nozzle_temp_max = wxString::Format("%d", opt_max_ints->get_at(0));
+                        m_input_nozzle_max->GetTextCtrl()->SetValue(text_nozzle_temp_max);
                     }
                 }
             }
@@ -1124,7 +1131,7 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
             m_readonly_filament->Hide();
         }
 
-        if (obj->GetCalib()->IsVersionInited()) {
+        if (obj->cali_version >= 0) {
             m_title_pa_profile->Show();
             m_comboBox_cali_result->Show();
             m_input_k_val->Disable();

--- a/src/slic3r/GUI/PrinterWebView.cpp
+++ b/src/slic3r/GUI/PrinterWebView.cpp
@@ -2285,7 +2285,7 @@ void PrinterWebView::updateDeviceParameter(const std::string& device_id) {
                         cans[i].material_colour = wxColour(device->m_boxData[i].colorHexCode);
                         cans[i].material_name = device->m_boxData[i].name;
                         cans[i].material_state = AMSCanType::AMS_CAN_TYPE_VIRTUAL;
-                        cans[i].ctype = device->m_boxData[i].vendor == "Generic" ? 0 : 1;
+                        cans[i].ctype = device->m_boxData[i].vendor == "QIDI" ? 1 : 0;
                     }
                     else {
                         cans[i].material_colour = *wxWHITE;

--- a/src/slic3r/GUI/QDSDeviceManager.cpp
+++ b/src/slic3r/GUI/QDSDeviceManager.cpp
@@ -1,6 +1,8 @@
 #include "QDSDeviceManager.hpp"
+#include <algorithm>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/ini_parser.hpp>
+#include <cctype>
 #include <random>
 #include "libslic3r/Utils.hpp"
 #include "GUI_App.hpp"
@@ -19,6 +21,91 @@
 
 namespace Slic3r {
 namespace GUI {
+
+namespace {
+
+std::string normalize_filament_key(std::string value)
+{
+    auto not_space = [](unsigned char ch) { return !std::isspace(ch); };
+    value.erase(value.begin(), std::find_if(value.begin(), value.end(), not_space));
+    value.erase(std::find_if(value.rbegin(), value.rend(), not_space).base(), value.end());
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return value;
+}
+
+std::string normalized_preset_vendor(const Preset& preset, const std::string& shown_name)
+{
+    std::string vendor = normalize_filament_key(preset.config.get_filament_vendor());
+    if (!vendor.empty())
+        return vendor;
+    if (normalize_filament_key(shown_name).rfind("qidi ", 0) == 0)
+        return "qidi";
+    return vendor;
+}
+
+std::string resolve_connected_filament_id(const QDSDevice::Filament& filament)
+{
+    auto* preset_bundle = wxGetApp().preset_bundle;
+    if (preset_bundle == nullptr)
+        return {};
+
+    const std::string target_name = normalize_filament_key(filament.name);
+    if (target_name.empty())
+        return {};
+
+    const std::string target_type = normalize_filament_key(filament.type);
+    const std::string target_vendor = normalize_filament_key(filament.vendor);
+    std::string type_match_id;
+    std::string fallback_id;
+
+    auto& filaments = preset_bundle->filaments;
+    for (auto filament_it = filaments.begin(); filament_it != filaments.end(); ++filament_it) {
+        const std::string alias = filaments.get_preset_alias(*filament_it, true);
+        const std::string shown_name = alias.empty() ? filament_it->name : alias;
+        const std::string normalized_name = normalize_filament_key(shown_name);
+        const std::string normalized_internal_name = normalize_filament_key(filament_it->name);
+        if (normalized_name != target_name && normalized_internal_name != target_name)
+            continue;
+
+        const std::string candidate_type = normalize_filament_key(filament_it->config.get_filament_type());
+        const std::string candidate_vendor = normalized_preset_vendor(*filament_it, shown_name);
+        const bool type_matches = target_type.empty() || candidate_type.empty() || candidate_type == target_type;
+        const bool vendor_matches = target_vendor.empty() || candidate_vendor.empty() || candidate_vendor == target_vendor;
+
+        if (type_matches && vendor_matches)
+            return filament_it->filament_id;
+
+        if (type_matches && type_match_id.empty())
+            type_match_id = filament_it->filament_id;
+        if (fallback_id.empty())
+            fallback_id = filament_it->filament_id;
+    }
+
+    if (!type_match_id.empty())
+        return type_match_id;
+    return fallback_id;
+}
+
+std::string build_legacy_connected_filament_id(const QDSDevice& device, const QDSDevice::Filament& filament)
+{
+    static const std::unordered_map<std::string, std::string> machine_mapping = {
+        {"X-Plus 4", "0"},
+        {"Q2", "1"},
+        {"Q2C", "2"},
+        {"X-Max 4", "3"}
+    };
+
+    const auto machine_it = machine_mapping.find(device.m_type);
+    if (machine_it == machine_mapping.end() || filament.filament_idex < 0)
+        return {};
+
+    const std::string vendor_bit = filament.vendor == "QIDI" ? "1" : "0";
+    return "QD_" + machine_it->second + "_" + vendor_bit + "_" + std::to_string(filament.filament_idex);
+}
+
+} // namespace
 
 namespace pt = boost::property_tree;
 std::vector<QDSDevice::Filament> QDSDevice::m_general_filamentConfig;


### PR DESCRIPTION
Connected AMS slots were being reduced back to legacy QD_* ids and a binary vendor model after reading live printer state. That worked for the old stock catalog but broke connected-device material identity for expanded and custom filament entries.

This change keeps the connected-device AMS path aligned with the actual live printer data and the expanded official filament catalog.

What changed:
- resolve connected AMS slot materials against the real local preset catalog by name, type, and vendor before falling back to the legacy QD_* id formula
- fix the device-page tray classification so only exact QIDI vendor is treated as QIDI
- restore the AMS material picker logic so it uses the current printer and nozzle context instead of the stale hardcoded path
- sync the bundled officiall_filas_list.cfg to the same verified full catalog used on the live printer and in the Q2 repo update

Why:
- the live printer fix only solves the source catalog side
- QIDIStudio still needed to stop collapsing connected AMS materials back into the old official-id model on the client side

Validation:
- verified the live printer first with the expanded printer-side file before preparing this repo change
- editor diagnostics report no errors in the modified AMS files