### PR TITLE
fix crashes when moving the main window between monitors with different DPI

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -7665,6 +7665,12 @@ void GLCanvas3D::_resize(unsigned int w, unsigned int h)
     font_size *= 1.5f;
 #endif
 
+    // Ensure this canvas' GL context is current before set_scaling() below, which can
+    // destroy/recreate the (app-wide, shared-context) ImGui font texture via raw GL calls.
+    // Without this, the shared wxGLContext may still be bound to a different canvas' device
+    // context, causing a GL call issued against the wrong context.
+    _set_current(true);
+
 #if ENABLE_RETINA_GL
     imgui->set_scaling(font_size, 1.0f, m_retina_helper->get_scale_factor());
 #else
@@ -7672,9 +7678,6 @@ void GLCanvas3D::_resize(unsigned int w, unsigned int h)
 #endif
 
     this->request_extra_frame();
-
-    // ensures that this canvas is current
-    _set_current(true);
 }
 
 BoundingBoxf3 GLCanvas3D::_max_bounding_box(bool include_gizmos, bool include_bed_model, bool include_plates, bool volumes_limit_to_expand_plate) const

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -783,7 +783,7 @@ struct Sidebar::priv
     wxStaticText* m_staticText_filament_settings;
     ScalableButton *  m_bpButton_add_filament;
     ScalableButton *  m_bpButton_del_filament;
-    ScalableButton *  m_bpButton_ams_filament;
+    // ScalableButton *  m_bpButton_ams_filament;
     //y59
     ScalableButton *  m_bpButton_box_filament;
     ScalableButton *  m_bpButton_set_filament;
@@ -4217,7 +4217,7 @@ void Sidebar::msw_rescale()
     p->m_filament_icon->msw_rescale();
     p->m_bpButton_add_filament->msw_rescale();
     p->m_bpButton_del_filament->msw_rescale();
-    p->m_bpButton_ams_filament->msw_rescale();
+    // p->m_bpButton_ams_filament->msw_rescale();
     p->m_bpButton_set_filament->msw_rescale();
     p->m_flushing_volume_btn->Rescale();
     p->m_purge_mode_btn->Rescale();


### PR DESCRIPTION
GLCanvas3D::_resize() called ImGui::set_scaling() (which can destroy/ recreate the shared font texture via raw GL calls) before making the canvas's own GL context current, risking a GL call against the wrong context when multiple canvases share one wxGLContext during a rescale storm. Move _set_current(true) before the ImGui call.

Sidebar::msw_rescale() unconditionally called msw_rescale() on m_bpButton_ams_filament, a button that is never constructed anywhere in the codebase (dead member from a removed feature). This null- pointer dereference fired on every DPI-change event and was the primary cause of the crash.

Fixes #194